### PR TITLE
Add ability to save node comments and status overrides

### DIFF
--- a/protos/graph_structures.proto
+++ b/protos/graph_structures.proto
@@ -16,6 +16,7 @@ message Node { // all names are fully qualified (grandparent.parent.this_node.ch
     repeated Dependency dependencies = 6;
     repeated SLI slis = 7;
     optional string comment = 8;
+    optional Status override_status = 9;
 }
 
 message Dependency {
@@ -67,6 +68,7 @@ message VirtualNode {
     // ---
     optional Status status = 5;
     optional string comment = 6;
+    optional Status override_status = 7;
 }
 
 enum Status {

--- a/protos/graph_structures.proto
+++ b/protos/graph_structures.proto
@@ -57,6 +57,8 @@ message Client {
     optional string name = 1;
     repeated UserJourney user_journeys = 2;
     // ---
+
+    optional string comment = 3;
 }
 
 message VirtualNode {

--- a/protos/graph_structures.proto
+++ b/protos/graph_structures.proto
@@ -66,6 +66,7 @@ message VirtualNode {
 
     // ---
     optional Status status = 5;
+    optional string comment = 6;
 }
 
 enum Status {

--- a/protos/server.proto
+++ b/protos/server.proto
@@ -10,7 +10,7 @@ service ReportingService {
     // for user journeys
     rpc GetClients(ClientRequest) returns (ClientResponse) {}
 
-    //rpc SetComment(CommentRequest) returns (CommentResponse) {}
+    rpc SetComment(CommentRequest) returns (CommentResponse) {}
 }
 
 message NodeRequest {
@@ -38,4 +38,13 @@ message ClientRequest {
 
 message ClientResponse {
     repeated Client clients = 1;
+}
+
+message CommentRequest {
+    optional string node_name = 1;
+    optional string comment = 2;
+}
+
+message CommentResponse {
+    // ...
 }

--- a/protos/server.proto
+++ b/protos/server.proto
@@ -10,9 +10,6 @@ service ReportingService {
     // for user journeys
     rpc GetClients(GetClientsRequest) returns (GetClientsResponse) {}
 
-    rpc SetComment(SetCommentRequest) returns (SetCommentResponse) {}
-
-    rpc SetOverrideStatus(SetOverrideStatusRequest) returns (SetOverrideStatusResponse) {}
 }
 
 message GetNodesRequest {
@@ -40,22 +37,4 @@ message GetClientsRequest {
 
 message GetClientsResponse {
     repeated Client clients = 1;
-}
-
-message SetCommentRequest {
-    optional string node_name = 1;
-    optional string comment = 2;
-}
-
-message SetCommentResponse {
-    // ...
-}
-
-message SetOverrideStatusRequest {
-    optional string node_name = 1;
-    optional Status override_status = 2;
-}
-
-message SetOverrideStatusResponse {
-    // ...
 }

--- a/protos/server.proto
+++ b/protos/server.proto
@@ -4,47 +4,58 @@ package ujt_protos;
 
 service ReportingService {
     // for generating graph
-    rpc GetNodes(NodeRequest) returns (NodeResponse) {}
+    rpc GetNodes(GetNodesRequest) returns (GetNodesResponse) {}
     // for updating statuses
-    rpc GetSLIs(SLIRequest) returns (SLIResponse) {}
+    rpc GetSLIs(GetSLIsRequest) returns (GetSLIsResponse) {}
     // for user journeys
-    rpc GetClients(ClientRequest) returns (ClientResponse) {}
+    rpc GetClients(GetClientsRequest) returns (GetClientsResponse) {}
 
-    rpc SetComment(CommentRequest) returns (CommentResponse) {}
+    rpc SetComment(SetCommentRequest) returns (SetCommentResponse) {}
+
+    rpc SetOverrideStatus(SetOverrideStatusRequest) returns (SetOverrideStatusResponse) {}
 }
 
-message NodeRequest {
-    // add filtering fields later...
-    // not sure if it's necessary/useful to request a subset of nodes
-    // I imagine nodes should be requested once at startup (and perhaps force-refreshed)
+message GetNodesRequest {
+    // We can add filtering fields later.
+    // Not sure if it's necessary/useful to request a subset of nodes.
+    // I imagine nodes should be requested once at startup (and perhaps force-refreshed), 
+    // which should both request all nodes.
 }
 
-message NodeResponse {
+message GetNodesResponse {
     repeated Node nodes = 1;
 }
 
-message SLIRequest {
-    // same situation as NodeResponse, not sure when we need to request individual SLIs.
-    // we can add fields later if it becomes necessary
-}
-
-message SLIResponse {
-    repeated SLI slis = 1;
-}
-
-message ClientRequest {
+message GetSLIsRequest {
     // ...
 }
 
-message ClientResponse {
+message GetSLIsResponse {
+    repeated SLI slis = 1;
+}
+
+message GetClientsRequest {
+    // ...
+}
+
+message GetClientsResponse {
     repeated Client clients = 1;
 }
 
-message CommentRequest {
+message SetCommentRequest {
     optional string node_name = 1;
     optional string comment = 2;
 }
 
-message CommentResponse {
+message SetCommentResponse {
+    // ...
+}
+
+message SetOverrideStatusRequest {
+    optional string node_name = 1;
+    optional Status override_status = 2;
+}
+
+message SetOverrideStatusResponse {
     // ...
 }

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -153,7 +153,7 @@ def test_datatable_from_client():
         table_id=table_id,
     )
 
-    assert table.id == {"datatable-id": table_id}  # pylint: disable=no-member
+    assert table.id == {table_id: table_id}  # pylint: disable=no-member
     assert table.columns == expected_columns  # pylint: disable=no-member
     assert table.data == expected_data  # pylint: disable=no-member
     assert table.style_data_conditional == ujt.constants.DATATABLE_CONDITIONAL_STYLE  # pylint: disable=no-member

--- a/ujt/callbacks.py
+++ b/ujt/callbacks.py
@@ -138,11 +138,11 @@ def update_graph_elements(
 
         if triggered_id == r"""{"override-dropdown":"override-dropdown"}""":
             node_name = tap_node["data"]["ujt_id"]
-            if node_name in node_name_message_map:
-                node_name_message_map[
-                    node_name].override_status = triggered_value
-            else:
-                virtual_node_map[node_name].override_status = triggered_value
+            state.set_node_override_status(
+                node_name,
+                triggered_value,
+                node_name_message_map=node_name_message_map,
+                virtual_node_map=virtual_node_map)
 
         # Perform status computation.
         # We can refactor this block later as well, but no other function should call it...
@@ -474,6 +474,9 @@ def validate_selected_nodes_for_virtual_node(
             return "Error: Must select at least one node to to add to virtual node."
 
         node_name_message_map, client_name_message_map = state.get_message_maps()
+        if virtual_node_name in node_name_message_map or virtual_node_name in client_name_message_map:
+            return "Error: Virtual node cannot share a name with a real node or client."
+
         for node_data in selected_node_data:
             if node_data["ujt_id"] in client_name_message_map:
                 return "Error: Cannot add clients to virtual node."
@@ -598,7 +601,7 @@ def discard_comment(discard_n_clicks_timestamp, tap_node):
     ],
     prevent_initial_call=True,
 )
-def save_discard_comment(save_n_clicks_timestamp, tap_node, new_comment):
+def save_comment(save_n_clicks_timestamp, tap_node, new_comment):
     """ Handles the functionality for saving comments
 .
     This function is called:
@@ -618,5 +621,5 @@ def save_discard_comment(save_n_clicks_timestamp, tap_node, new_comment):
 
     new_comment = new_comment[0]
     node_name = tap_node["data"]["ujt_id"]
-    state.set_node_comment(node_name, new_comment)
+    state.set_comment(node_name, new_comment)
     return True

--- a/ujt/compute_status.py
+++ b/ujt/compute_status.py
@@ -65,7 +65,8 @@ def compute_single_node_status(
     """
 
     node = node_name_message_map[node_name]
-    if node.status != Status.STATUS_UNSPECIFIED:
+
+    if node.status != Status.STATUS_UNSPECIFIED:  # if the current node's status was already computed
         return node.status
 
     status_count_map: Dict["StatusValue", int] = defaultdict(int)
@@ -89,6 +90,12 @@ def compute_single_node_status(
         pass
 
     node.status = compute_status_from_count_map(status_count_map)
+
+    if node.override_status != Status.STATUS_UNSPECIFIED:  # if the current node's status was manually overwritten
+        # notice we place this at the end, since we still want to compute the node's status
+        # to display in the dropdown menu (regardless of the override)
+        return node.override_status
+
     return node.status
 
 

--- a/ujt/constants.py
+++ b/ujt/constants.py
@@ -6,6 +6,7 @@ from graph_structures_pb2 import NodeType, Status
 
 CLIENT_CLASS = "CLIENT"
 HIGHLIGHTED_UJ_EDGE_CLASS = "HIGHLIGHTED_UJ_EDGE"
+OVERRIDE_CLASS = "OVERRIDE"
 OK_SIGNAL = "OK"
 
 HEALTHY_COLOR = "green"
@@ -36,10 +37,12 @@ CYTO_STYLESHEET = [
     },
     {
         "selector": "edge",
-        "style": {
-            "curve-style": "straight",
-            "target-arrow-shape": "triangle",
-        }
+        "style":
+            {
+                "curve-style": "straight",
+                "target-arrow-shape": "triangle",
+                "arrow-scale": 2,
+            }
     },
     {
         "selector": f".{NodeType.Name(NodeType.NODETYPE_SERVICE)}",
@@ -89,6 +92,12 @@ CYTO_STYLESHEET = [
                 "shape": "octagon",
                 "background-blacken": VIRTUAL_BACKGROUND_BLACKEN_FACTOR,
             }
+    },
+    {
+        "selector": f".{OVERRIDE_CLASS}",
+        "style": {
+            "shape": "tag",
+        }
     }
 ]
 

--- a/ujt/constants.py
+++ b/ujt/constants.py
@@ -4,6 +4,8 @@ Generally contains constants for styling.
 """
 from graph_structures_pb2 import NodeType, Status
 
+CLEAR_CACHE_ON_STARTUP = False
+
 CLIENT_CLASS = "CLIENT"
 HIGHLIGHTED_UJ_EDGE_CLASS = "HIGHLIGHTED_UJ_EDGE"
 OVERRIDE_CLASS = "OVERRIDE"

--- a/ujt/converters.py
+++ b/ujt/converters.py
@@ -228,7 +228,7 @@ def datatable_from_client(client, table_id):
     return dash_table.DataTable(
         # We provide a dict as an id here to utilize the callback
         # pattern matching functionality, since no datatable exists on startup
-        id={"datatable-id": table_id},
+        id={table_id: table_id},
         columns=columns,
         data=data,
         row_selectable="single",
@@ -245,3 +245,24 @@ def dropdown_options_from_client_map(
             "value": name,
         } for name in client_name_message_map.keys()
     ]
+
+
+def override_dropdown_options_from_node(node):
+    options = [
+        {
+            "label":
+                f"OVERRIDE: {utils.human_readable_enum_name(value_descriptor.number, Status)}",
+            "value":
+                value_descriptor.number,
+        }
+        for value_descriptor in Status.DESCRIPTOR.values
+        if value_descriptor.number != Status.STATUS_UNSPECIFIED
+    ]
+    options.append(
+        {
+            "label":
+                f"AUTOMATIC ({utils.human_readable_enum_name(node.status, Status)})",
+            "value":
+                Status.STATUS_UNSPECIFIED  # this should be zero
+        })
+    return options

--- a/ujt/converters.py
+++ b/ujt/converters.py
@@ -226,7 +226,8 @@ def datatable_from_client(client, table_id):
         } for user_journey in client.user_journeys
     ]
     return dash_table.DataTable(
-        # We provide a dict as an id here to utilize the callback pattern matching functionality
+        # We provide a dict as an id here to utilize the callback
+        # pattern matching functionality, since no datatable exists on startup
         id={"datatable-id": table_id},
         columns=columns,
         data=data,

--- a/ujt/dash_app.py
+++ b/ujt/dash_app.py
@@ -20,9 +20,3 @@ cache.init_app(
         "CACHE_DIR": "cache_dir"
     },
 )
-# To persist virtual nodes across server sessions,
-# we need to save virtual nodes as protos to disk and read them here.
-# this is a temporary solution.
-cache.clear()
-cache.set("virtual_node_map", {})
-cache.set("parent_virtual_node_map", {})

--- a/ujt/rpc_client.py
+++ b/ujt/rpc_client.py
@@ -6,9 +6,15 @@ These functions are 1:1 passthroughs right now, but we may need to do
 some additional data processing as the application grows.
 """
 
+from typing import TYPE_CHECKING, Type
+
 import grpc
 import server_pb2
 import server_pb2_grpc
+
+if TYPE_CHECKING:
+    from graph_structures_pb2 import \
+        StatusValue  # pylint: disable=no-name-in-module  # pragma: no cover
 
 # Let's hardcode this for now... later can move into cfg file. Doesn't really fit in constants file
 # Not sure how to provide it as a cmd line argument from ujt module.
@@ -18,17 +24,17 @@ reporting_service_stub = server_pb2_grpc.ReportingServiceStub(channel)
 
 def get_nodes():
     """ Reads a list of Nodes from the remote Reporting Service. """
-    return reporting_service_stub.GetNodes(server_pb2.NodeRequest())
+    return reporting_service_stub.GetNodes(server_pb2.GetNodesRequest())
 
 
 def get_clients():
     """ Reads a list of Clients from the remote Reporting Service. """
-    return reporting_service_stub.GetClients(server_pb2.ClientRequest())
+    return reporting_service_stub.GetClients(server_pb2.GetClientsRequest())
 
 
 def get_slis():
     """ Reads a list of SLIs from the remote Reporting Service. """
-    return reporting_service_stub.GetSLIs(server_pb2.SLIRequest())
+    return reporting_service_stub.GetSLIs(server_pb2.GetSLIsRequest())
 
 
 def set_comment(node_name: str, comment: str):
@@ -39,5 +45,18 @@ def set_comment(node_name: str, comment: str):
         comment: The comment to give to the node.
     """
     reporting_service_stub.SetComment(
-        server_pb2.CommentRequest(node_name=node_name,
-                                  comment=comment))
+        server_pb2.SetCommentRequest(node_name=node_name,
+                                     comment=comment))
+
+
+def set_override_status(node_name: str, override_status: "StatusValue"):
+    """ Requests the reporting server to update the override status for a given node.
+    
+    Args:
+        node_name: The name of the node to update.
+        override_status: The new status to give to the node.
+    """
+    reporting_service_stub.SetOverrideStatus(
+        server_pb2.SetOverrideStatusRequest(
+            node_name=node_name,
+            override_status=override_status))

--- a/ujt/rpc_client.py
+++ b/ujt/rpc_client.py
@@ -35,28 +35,3 @@ def get_clients():
 def get_slis():
     """ Reads a list of SLIs from the remote Reporting Service. """
     return reporting_service_stub.GetSLIs(server_pb2.GetSLIsRequest())
-
-
-def set_comment(node_name: str, comment: str):
-    """ Requests the reporting server to update the comment for a given node.
-    
-    Args:
-        node_name: The name of the node to update.
-        comment: The comment to give to the node.
-    """
-    reporting_service_stub.SetComment(
-        server_pb2.SetCommentRequest(node_name=node_name,
-                                     comment=comment))
-
-
-def set_override_status(node_name: str, override_status: "StatusValue"):
-    """ Requests the reporting server to update the override status for a given node.
-    
-    Args:
-        node_name: The name of the node to update.
-        override_status: The new status to give to the node.
-    """
-    reporting_service_stub.SetOverrideStatus(
-        server_pb2.SetOverrideStatusRequest(
-            node_name=node_name,
-            override_status=override_status))

--- a/ujt/rpc_client.py
+++ b/ujt/rpc_client.py
@@ -29,3 +29,15 @@ def get_clients():
 def get_slis():
     """ Reads a list of SLIs from the remote Reporting Service. """
     return reporting_service_stub.GetSLIs(server_pb2.SLIRequest())
+
+
+def set_comment(node_name: str, comment: str):
+    """ Requests the reporting server to update the comment for a given node.
+    
+    Args:
+        node_name: The name of the node to update.
+        comment: The comment to give to the node.
+    """
+    reporting_service_stub.SetComment(
+        server_pb2.CommentRequest(node_name=node_name,
+                                  comment=comment))

--- a/ujt/server/client.py
+++ b/ujt/server/client.py
@@ -6,11 +6,11 @@ import server_pb2_grpc
 with grpc.insecure_channel("localhost:50051") as channel:  # pragma: no cover
     stub = server_pb2_grpc.ReportingServiceStub(channel)
 
-    node_request = server_pb2.NodeRequest()
+    node_request = server_pb2.GetNodesRequest()
     node_response = stub.GetNodes(node_request)
     print(node_response.nodes)
 
-    sli_request = server_pb2.SLIRequest()
+    sli_request = server_pb2.GetSLIsRequest()
     #sli_response = stub.get_slis(sli_request)
     sli_response = stub.GetSLIs(sli_request)
     print(sli_response.slis)

--- a/ujt/server/server.py
+++ b/ujt/server/server.py
@@ -77,6 +77,13 @@ class ReportingServiceServicer(server_pb2_grpc.ReportingServiceServicer):
             node.slis.extend([sli_name_map[node.name]])
         return server_pb2.SLIResponse(slis=slis)
 
+    def SetComment(self, request, context):
+        for node in self.nodes:
+            if node.name == request.node_name:
+                node.comment = request.comment
+
+        return server_pb2.CommentResponse()
+
 
 def serve():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))

--- a/ujt/server/server.py
+++ b/ujt/server/server.py
@@ -78,22 +78,6 @@ class ReportingServiceServicer(server_pb2_grpc.ReportingServiceServicer):
             node.slis.extend([sli_name_map[node.name]])
         return server_pb2.GetSLIsResponse(slis=slis)
 
-    def SetComment(self, request, context):
-        for node in self.nodes:
-            if node.name == request.node_name:
-                node.comment = request.comment
-
-        return server_pb2.SetCommentResponse()
-
-    def SetOverrideStatus(self, request, context):
-        # Same code structure as SetComment,
-        # maybe should change nodes and clients from lists to dicts
-        for node in self.nodes:
-            if node.name == request.node_name:
-                node.override_status = request.override_status
-
-        return server_pb2.SetOverrideStatusResponse()
-
 
 def serve():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))

--- a/ujt/server/server.py
+++ b/ujt/server/server.py
@@ -4,6 +4,7 @@ import glob
 import pathlib
 import random
 from concurrent import futures
+from typing import List
 
 import google.protobuf.text_format as text_format
 import grpc
@@ -49,14 +50,14 @@ class ReportingServiceServicer(server_pb2_grpc.ReportingServiceServicer):
     """Provides methods that implement functionality of Reporting Service."""
 
     def __init__(self, nodes, clients):
-        self.nodes = nodes
-        self.clients = clients
+        self.nodes: List[Node] = nodes
+        self.clients: List[Client] = clients
 
     def GetNodes(self, request, context):
-        return server_pb2.NodeResponse(nodes=self.nodes)
+        return server_pb2.GetNodesResponse(nodes=self.nodes)
 
     def GetClients(self, request, context):
-        return server_pb2.ClientResponse(clients=self.clients)
+        return server_pb2.GetClientsResponse(clients=self.clients)
 
     def GetSLIs(self, request, context):
         """ Returns updated SLI values to clients.
@@ -75,14 +76,23 @@ class ReportingServiceServicer(server_pb2_grpc.ReportingServiceServicer):
 
             del node.slis[:]
             node.slis.extend([sli_name_map[node.name]])
-        return server_pb2.SLIResponse(slis=slis)
+        return server_pb2.GetSLIsResponse(slis=slis)
 
     def SetComment(self, request, context):
         for node in self.nodes:
             if node.name == request.node_name:
                 node.comment = request.comment
 
-        return server_pb2.CommentResponse()
+        return server_pb2.SetCommentResponse()
+
+    def SetOverrideStatus(self, request, context):
+        # Same code structure as SetComment,
+        # maybe should change nodes and clients from lists to dicts
+        for node in self.nodes:
+            if node.name == request.node_name:
+                node.override_status = request.override_status
+
+        return server_pb2.SetOverrideStatusResponse()
 
 
 def serve():

--- a/ujt/state.py
+++ b/ujt/state.py
@@ -1,10 +1,20 @@
 from collections import deque
-from typing import Any, Deque, Dict, List, Set, Tuple, cast
+from typing import TYPE_CHECKING, Any, Deque, Dict, List, Set, Tuple, cast
 
-from graph_structures_pb2 import SLI, Client, Node, NodeType, VirtualNode
+from graph_structures_pb2 import (
+    SLI,
+    Client,
+    Node,
+    NodeType,
+    Status,
+    VirtualNode)
 
 from . import converters, rpc_client, utils
 from .dash_app import cache
+
+if TYPE_CHECKING:
+    from graph_structures_pb2 import \
+        StatusValue  # pylint: disable=no-name-in-module  # pragma: no cover
 
 
 def clear_sli_cache():
@@ -230,21 +240,112 @@ def set_virtual_node_collapsed_state(virtual_node_name: str, collapsed: bool):
 # endregion
 
 
-def set_node_comment(node_name: str, comment: str):
-    node_name_message_map = get_node_name_message_map()
-    virtual_node_map = get_virtual_node_map()
+def set_comment(
+    name: str,
+    comment: str,
+    node_name_message_map: Dict[str,
+                                Node] = None,
+    client_name_message_map: Dict[str,
+                                  Client] = None,
+    virtual_node_map: Dict[str,
+                           VirtualNode] = None,
+):
+    """ Sets the node comment in the appropriate node map.
 
-    if node_name in node_name_message_map:
-        node = node_name_message_map[node_name]
-        is_virtual_node = False
+    Addiionally adds the override status to an internal map. 
+    This internal map is combined with the graph topology when the topology is read from the reporting server.
+
+    Args:
+        name: The name of the node or client to modify.
+        comment: The comment to write to the node or client
+        node_name_message_map: A dictionary mapping node names to Nodes. Used when we want to modify the state of an existing map without reading from cache.
+        client_name_message_map: A dictionary mapping client names to Clients. Used when we want to modify the state of an existing map without reading from cache.
+        virtual_node_map: A dictionary mapping virtual node names to VirtualNodes. Used when we want to modify the state of an existing map without reading from cache.
+    """
+
+    save_changes = False
+
+    maps = [node_name_message_map, client_name_message_map, virtual_node_map]
+    getters = [
+        get_node_name_message_map,
+        get_client_name_message_map,
+        get_virtual_node_map
+    ]
+    setters = [
+        set_node_name_message_map,
+        set_client_name_message_map,
+        set_virtual_node_map
+    ]
+
+    for idx, proto_map in enumerate(maps):
+        if proto_map is None:
+            proto_map = getters[idx]()  # type: ignore
+            save_changes = True
+        if name in proto_map:  # type: ignore
+            proto_map[name].comment = comment  # type: ignore
+            if save_changes:
+                setters[idx](proto_map)
+
+    comment_map = cache.get("comment_map")
+    if comment == "":
+        try:
+            del comment_map[name]
+        except KeyError:  # the node didn't have a comment before
+            pass
     else:
-        node = virtual_node_map[node_name]  # type: ignore
-        is_virtual_node = True
+        comment_map[name] = comment
+    cache.set("comment_map", comment_map)
 
-    node.comment = comment
 
-    if not is_virtual_node:
-        set_node_name_message_map(node_name_message_map)
-        rpc_client.set_comment(node.name, node.comment)
+def set_node_override_status(
+    node_name: str,
+    override_status: "StatusValue",
+    node_name_message_map: Dict[str,
+                                Node] = None,
+    virtual_node_map: Dict[str,
+                           VirtualNode] = None,
+):
+    """ Sets the node override status in the appropriate node map.
+
+    Addiionally adds the override status to an internal map. 
+    This internal map is combined with the graph topology when the topology is read from the reporting server.
+
+    Notice that this function doesn't read and write from the cache if maps were provided in the arguments.
+    The maps should be provided when the caller is in the middle of a modification (a "transaction") of the message maps.
+    For instance,
+        node_name_message_map = state.get_node_name_message_map()
+        modify_map(node_name_message_map)
+        set_node_override_status(node_name, override_status, node_name_message_map, virtual_node_map)
+        state.set_node_name_message_map(node_name_message_map)
+        
+    Args:
+        node_name: The name of the node to modify.
+        override_status: The override status to write to the node
+        node_name_message_map: A dictionary mapping node names to Nodes. Used when we want to modify the state of an existing map without reading from cache.
+        virtual_node_map: A dictionary mapping virtual node names to VirtualNodes. Used when we want to modify the state of an existing map without reading from cache.
+    """
+    save_changes = False
+
+    maps = [node_name_message_map, virtual_node_map]
+    getters = [get_node_name_message_map, get_virtual_node_map]
+    setters = [set_node_name_message_map, set_virtual_node_map]
+
+    for idx, proto_map in enumerate(maps):
+        if proto_map is None:
+            maps[idx] = getters[idx]()  # type: ignore
+            save_changes = True
+        if node_name in proto_map:  # type: ignore
+            proto_map[  # type: ignore
+                node_name].override_status = override_status  # type: ignore
+            if save_changes:
+                setters[idx](proto_map)
+
+    override_status_map = cache.get("override_status_map")
+    if override_status == Status.STATUS_UNSPECIFIED:
+        try:
+            del override_status_map[node_name]
+        except KeyError:  # the node didn't have a comment before
+            pass
     else:
-        set_virtual_node_map(virtual_node_map)
+        override_status_map[node_name] = override_status
+    cache.set("override_status_map", override_status_map)

--- a/ujt/state.py
+++ b/ujt/state.py
@@ -228,3 +228,23 @@ def set_virtual_node_collapsed_state(virtual_node_name: str, collapsed: bool):
 
 
 # endregion
+
+
+def set_node_comment(node_name: str, comment: str):
+    node_name_message_map = get_node_name_message_map()
+    virtual_node_map = get_virtual_node_map()
+
+    if node_name in node_name_message_map:
+        node = node_name_message_map[node_name]
+        is_virtual_node = False
+    else:
+        node = virtual_node_map[node]
+        is_virtual_node = True
+
+    node.comment = comment
+
+    if not is_virtual_node:
+        set_node_name_message_map(node_name_message_map)
+        rpc_client.set_comment(node.name, node.comment)
+    else:
+        set_virtual_node_map(virtual_node_map)

--- a/ujt/state.py
+++ b/ujt/state.py
@@ -238,7 +238,7 @@ def set_node_comment(node_name: str, comment: str):
         node = node_name_message_map[node_name]
         is_virtual_node = False
     else:
-        node = virtual_node_map[node]
+        node = virtual_node_map[node_name]  # type: ignore
         is_virtual_node = True
 
     node.comment = comment

--- a/ujt/transformers.py
+++ b/ujt/transformers.py
@@ -37,11 +37,16 @@ def apply_node_classes(
         else:  # element_ujt_id in virtual_node_map
             node = virtual_node_map[element_ujt_id]
 
-        element["classes"] = " ".join(
-            [
-                NodeType.Name(node.node_type),
-                Status.Name(node.status),
-            ])  # use this join instead of format string for future flexibility
+        class_list = [NodeType.Name(node.node_type)]
+        if node.override_status != Status.STATUS_UNSPECIFIED:
+            class_list += [
+                Status.Name(node.override_status),
+                constants.OVERRIDE_CLASS
+            ]
+        else:
+            class_list += [Status.Name(node.status)]
+
+        element["classes"] = " ".join(class_list)
 
     # no return since we directly mutated elements
 

--- a/ujt/ujt.py
+++ b/ujt/ujt.py
@@ -136,9 +136,6 @@ def get_layout():
             get_top_row_components(),
             get_cytoscape_graph(),
             get_bottom_info_panels(),
-            html.Div(
-                id="virtual-node-update-signal",
-                style={"display": "none"}),
             dbc.Modal(
                 children=[
                     dbc.ModalHeader("Error"),
@@ -152,6 +149,9 @@ def get_layout():
                 ],
                 id="collapse-error-modal",
             ),
+            html.Div(
+                id="virtual-node-update-signal",
+                style={"display": "none"}),
         ],
     )
 

--- a/ujt/ujt.py
+++ b/ujt/ujt.py
@@ -7,7 +7,7 @@ import dash_html_components as html
 import dash_table
 
 from . import callbacks, constants, converters, state
-from .dash_app import app
+from .dash_app import app, cache
 
 
 def get_top_row_components():
@@ -156,6 +156,25 @@ def get_layout():
     )
 
 
+def initialize_ujt():
+    if constants.CLEAR_CACHE_ON_STARTUP:
+        cache.clear()
+    # If first time running server, set these persisted properties as dicts
+    map_names = [
+        "virtual_node_map",
+        "parent_virtual_node_map",
+        "comment_map",
+        "override_status_map"
+    ]
+    for map_name in map_names:
+        if cache.get(map_name) is None:
+            cache.set(map_name, {})
+
+    # Request and cache the dependency topology from the reporting server
+    state.get_message_maps()
+
+
 if __name__ == "__main__":
+    initialize_ujt()
     app.layout = get_layout()
     app.run_server(debug=True)


### PR DESCRIPTION
closes #20

waiting for #27 to be merged before removing draft status and adding PR comments of the interesting changes

Adding an override status to virtual nodes changes their color on the graph, but this override status is not propagated through the graph. This is because I designed virtual nodes to be a view over the graph, essentially a separate entity from the underlying topology/status computation. If this behavior is confusing we can look into changing the design of virtual nodes. 