### PR TITLE
Fix Cache Expiring

### DIFF
--- a/ujt/dash_app.py
+++ b/ujt/dash_app.py
@@ -15,5 +15,10 @@ app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 cache = Cache()
 cache.init_app(
     app.server,
-    config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "cache_dir"},
+    config={
+        "CACHE_TYPE": "filesystem",
+        "CACHE_DIR": "cache_dir",
+        "CACHE_DEFAULT_TIMEOUT": 0,
+        "CACHE_THRESHOLD": 0,
+    },
 )


### PR DESCRIPTION
closes #34 

We use Flask-Caching as a convenient interface to serialize our data structures to the file system. Since this isn't really a cache, we ensure that this doesn't expire.