### PR TITLE
Fix views to be stored in localstorage (browser)

### DIFF
--- a/ujt/callbacks/graph_callbacks.py
+++ b/ujt/callbacks/graph_callbacks.py
@@ -1,7 +1,7 @@
 """ Callbacks that modify properties of the cytoscape graph. 
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import dash
 from dash.dependencies import ALL, Input, Output, State
@@ -35,6 +35,7 @@ from ..dash_app import app
         State(id_constants.CYTOSCAPE_GRAPH, "selectedNodeData"),
         State(id_constants.VIRTUAL_NODE_INPUT, "value"),
         State(id_constants.CYTOSCAPE_GRAPH, "tapNode"),
+        State(id_constants.VIEW_STORE, "data"),
     ],
 )
 def update_graph_elements(
@@ -51,6 +52,7 @@ def update_graph_elements(
     selected_node_data: List[Dict[str, Any]],
     virtual_node_input_value: str,
     tap_node: Dict[str, Any],
+    view_list: List[Tuple[str, str]],
 ):
     """Update the elements of the cytoscape graph.
 
@@ -61,6 +63,7 @@ def update_graph_elements(
         when a virtual node is added or deleted (via the SIGNAL_VIRTUAL_NODE_UPDATE)
         when the collapse button is clicked virtual node
         when the expand button is clicked to expand virtual nodes
+        when a tag, style, or view is updated.
 
     We need this callback to handle these (generally unrelated) situations because Dash only supports assigning
     a single callback to a given output element.
@@ -84,6 +87,7 @@ def update_graph_elements(
             Used to perform all virtual node operations.
         tap_node: The cytoscape element of the latest tapped node.
             Used to check which node to override the status of.
+        view_list: The current list of views (specific to each browser).
     Returns:
         A dictionary of cytoscape elements describing the nodes and edges of the graph.
     """
@@ -186,7 +190,6 @@ def update_graph_elements(
     )
 
     tag_map = state.get_tag_map()
-    view_list = state.get_view_list()
     transformers.apply_views(
         elements,
         tag_map,

--- a/ujt/callbacks/panel_callbacks.py
+++ b/ujt/callbacks/panel_callbacks.py
@@ -1,11 +1,11 @@
 """ Callbacks that generate the panels below the cytoscape graph.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import dash_core_components as dcc
 import dash_html_components as html
-from dash.dependencies import Input, Output
+from dash.dependencies import Input, Output, State
 from dash.exceptions import PreventUpdate
 from graph_structures_pb2 import UserJourney
 
@@ -174,34 +174,35 @@ def generate_create_tag_panel(create_tag_signal, delete_tag_signal):
 @app.callback(
     Output(id_constants.VIEW_PANEL, "children"),
     [
-        Input(id_constants.SIGNAL_VIEW_CREATE, "children"),
-        Input(id_constants.SIGNAL_VIEW_DELETE, "children"),
+        Input(id_constants.SIGNAL_VIEW_UPDATE, "children"),
         Input(id_constants.SIGNAL_TAG_UPDATE, "children"),
         Input(id_constants.SIGNAL_STYLE_UPDATE, "children"),
     ],
+    State(id_constants.VIEW_STORE, "data"),
 )
 def generate_view_panel(
-    create_view_signal, delete_view_signal, tag_update_signal, style_update_signal
+    view_update_signal,
+    tag_update_signal,
+    style_update_signal,
+    view_list: List[Tuple[str, str]],
 ):
     """Handles generating the view creation and deletion panel.
 
     This function is called:
-        when a new view is created.
-        when a view is deleted.
+        when a view is updated.
         when a tag is updated.
         when a style is updated
 
     Args:
-        create_view_signal: Signal indicating that a view was created.
-            Value unused, input only provided to register callback.
-        delete_view_signal: Signal indicating that a view was deleted.
+        view_update_signal: Signal indicating that a view was updated.
             Value unused, input only provided to register callback.
         tag_update_signal: Signal indicating that a tag was updated.
             Value unused, input only provided to register callback.
         style_update_signal: Signal indicating that a style was updated.
             Value unused, input only provided to register callback.
+        view_list: The current list of views.
 
     Returns:
         A list of components to be placed in the VIEW_PANEL.
     """
-    return components.get_view_components()
+    return components.get_view_components(view_list)

--- a/ujt/callbacks/signal_callbacks.py
+++ b/ujt/callbacks/signal_callbacks.py
@@ -20,11 +20,6 @@ COMPOSITE_SIGNAL_MAP = {
         id_constants.SIGNAL_APPLIED_TAG_BATCH_ADD,
         id_constants.SIGNAL_APPLIED_TAG_BATCH_REMOVE,
     ),
-    id_constants.SIGNAL_VIEW_UPDATE: (
-        id_constants.SIGNAL_VIEW_CREATE,
-        id_constants.SIGNAL_VIEW_DELETE,
-        id_constants.SIGNAL_VIEW_MODIFY,
-    ),
     id_constants.SIGNAL_STYLE_UPDATE: (
         id_constants.SIGNAL_STYLE_SAVE,
         id_constants.SIGNAL_STYLE_DELETE,

--- a/ujt/callbacks/view_callbacks.py
+++ b/ujt/callbacks/view_callbacks.py
@@ -1,91 +1,21 @@
 """ Callbacks that handle view creation/deletion/modification functionality.
 """
 
+from typing import List, Tuple
 
 import dash
 from dash.dependencies import ALL, Input, Output
 from dash.exceptions import PreventUpdate
 
-from .. import constants, id_constants, state, utils
+from .. import constants, id_constants, utils
 from ..dash_app import app
 
 
 @app.callback(
-    Output(id_constants.SIGNAL_VIEW_CREATE, "children"),
-    Input({id_constants.CREATE_VIEW_BUTTON: ALL}, "n_clicks_timestamp"),
-)
-def create_view(create_timestamps):
-    """Handles creating views
-
-    This function is called:
-        when the create view button is clicked.
-
-    Args:
-        create_timestamps: List of the timestamps of the CREATE_VIEW_BUTTON buttons were called.
-            Value unused, input only provided to register callback.
-            Should only contain one value.
-
-    Returns:
-        A signal to add to the SIGNAL_VIEW_CREATE hidden div.
-    """
-    ctx = dash.callback_context
-    triggered_id, triggered_prop, triggered_value = utils.ctx_triggered_info(ctx)
-
-    # When the button is initially added, it fires a callback.
-    # We want to prevent this callback from making changes to the update signal.
-    if triggered_value is None:
-        raise PreventUpdate
-
-    state.create_view("", "")
-    return constants.OK_SIGNAL
-
-
-@app.callback(
-    Output(id_constants.SIGNAL_VIEW_DELETE, "children"),
-    Input(
-        {
-            id_constants.DELETE_VIEW_BUTTON: id_constants.DELETE_VIEW_BUTTON,
-            "index": ALL,
-        },
-        "n_clicks_timestamp",
-    ),
-    prevent_initial_call=True,
-)
-def delete_view(delete_timestamps):
-    """Handles deleting views from the view list.
-
-    This function is called:
-        when a delete view button is clicked
-
-    Args:
-        delete_timestamps: List of the timestamps of when DELETE_VIEW_BUTTON buttons were called.
-            Value unused, input only provided to register callback.
-            Should contain only one value.
-
-    Returns:
-        A signal to add to the SIGNAL_VIEW_DELETE hidden div.
-    """
-
-    ctx = dash.callback_context
-    triggered_id, triggered_prop, triggered_value = utils.ctx_triggered_info(ctx)
-
-    # When the button is initially added, it fires a callback.
-    # We want to prevent this callback from making changes to the update signal.
-    if triggered_value is None:
-        raise PreventUpdate
-
-    # Unfortunately, we have to convert the stringified dict back to a dict.
-    # Dash doesn't provide us any other method to see which element triggered the callback.
-    # This isn't very elegant, but I don't see any other way to proceed.
-    id_dict = utils.string_to_dict(triggered_id)
-    view_idx = id_dict["index"]
-    state.delete_view(view_idx)
-
-    return constants.OK_SIGNAL
-
-
-@app.callback(
-    Output(id_constants.SIGNAL_VIEW_MODIFY, "children"),
+    [
+        Output(id_constants.VIEW_STORE, "data"),
+        Output(id_constants.SIGNAL_VIEW_UPDATE, "children"),
+    ],
     [
         Input(
             {
@@ -101,38 +31,91 @@ def delete_view(delete_timestamps):
             },
             "value",
         ),
+        Input(
+            {
+                id_constants.CREATE_VIEW_BUTTON: ALL,
+            },
+            "n_clicks_timestamp",
+        ),
+        Input(
+            {
+                id_constants.DELETE_VIEW_BUTTON: id_constants.DELETE_VIEW_BUTTON,
+                "index": ALL,
+            },
+            "n_clicks_timestamp",
+        ),
     ],
-    prevent_initial_call=True,
 )
-def modify_view(tag_dropdown_values, style_dropdown_values):
-    """Updates the corresponding applied tag in the tag map.
+def update_view_store(
+    tag_dropdown_values, style_dropdown_values, create_timestamps, delete_timestamps
+) -> Tuple[List[Tuple[str, str]], str]:
+    """Saves the current list of views to the VIEW_STORE .
+
+    Notice that the style of this callback is different from the apply tag or create tag callbacks,
+    even though they both handle the same type of UI elements (dynamically creating rows).
+    This callback updates the VIEW_STORE by reading the current state of the rows of dropdown menus.
+    In turn, the generate_view_panel callback updates the dropdown menus based on the contents of the VIEW_STORE. 
+
+    Views are written to the VIEW_STORE in order to make them local for each user.
+    Thus, we must combine all the functionality into a single callback to write to the component.
+    This is in contrast to styles, tags, and applied tags, callbacks, which write
+    their respective data structure to the Dash server via the state module as a side effect.
+
+    We could theoretically refactor the tag creation panel and tag application panel to be in this style.
+    It would probably be a little cleaner in the case of the tag creation panel, since the panel only 
+    changes in response to create or delete tag buttons. 
+    In contrast, the tag application panel changes based on any tag update, its own apply/remove buttons, and 
+    user interactions with the cytoscape graph. 
+
+    This style offers a more functional approach, so we can be a little more confident in the correctness of
+    the state of our data structures. 
+    Moreover, it's relatively clean.
+
+    However, the complexity would probably increase dramatically in the apply tag callbacks case.
+    I think we can just accept this inconsistency in the view case and leave the other callbacks as-is.
 
     This function is called:
         when a VIEW_TAG_DROPDOWN value is updated
         when a VIEW_STYLE_DROPDOWN value is updated
+        when a view row is created
+        when a view row is deleted
 
     Args:
         tag_dropdown_values: the values of the VIEW_TAG_DROPDOWN dropdown menus.
         style_dropdown_values: the values of the VIEW_STYLE_DROPDOWN dropdown menus.
+        create_timestamps: the timestamp of when the CREATE_VIEW_BUTTON was clicked
+            Should contain only one element.
+        delete_timestamps: the timestamp of when the DELETE_VIEW_BUTTON was clicked
+            Should contain only one element.
 
     Returns:
         A signal to be placed in the SIGNAL_VIEW_MODIFY.
     """
     ctx = dash.callback_context
     triggered_id, triggered_prop, triggered_value = utils.ctx_triggered_info(ctx)
-
-    if triggered_value is None:
+    if triggered_id is None:
         raise PreventUpdate
+
+    tag_inputs = ctx.inputs_list[0]
+    style_inputs = ctx.inputs_list[1]
+
+    tag_inputs = sorted(tag_inputs, key=lambda x: x["id"]["index"])
+    style_inputs = sorted(style_inputs, key=lambda x: x["id"]["index"])
+
+    view_list = [
+        (tag_input["value"], style_input["value"])
+        for tag_input, style_input in zip(tag_inputs, style_inputs)
+    ]
 
     # Unfortunately, we have to convert the stringified dict back to a dict.
     # Dash doesn't provide us any other method to see which element triggered the callback.
     # This isn't very elegant, but I don't see any other way to proceed.
+
     id_dict = utils.string_to_dict(triggered_id)
-    view_idx = id_dict["index"]
 
-    tag_value = tag_dropdown_values[view_idx]
-    style_value = style_dropdown_values[view_idx]
+    if id_constants.CREATE_VIEW_BUTTON in id_dict and triggered_value is not None:
+        view_list.append(("", ""))
+    elif id_constants.DELETE_VIEW_BUTTON in id_dict and triggered_value is not None:
+        del view_list[id_dict["index"]]
 
-    state.update_view(view_idx, tag_value, style_value)
-
-    return constants.OK_SIGNAL
+    return view_list, constants.OK_SIGNAL

--- a/ujt/components.py
+++ b/ujt/components.py
@@ -11,7 +11,7 @@ Admittedly, this line is blurry, but it's nice to have a separate module to cont
 level functions to generate components, rather than placing them in ujt or callbacks.
 """
 
-from typing import List, Union
+from typing import List, Tuple, Union
 
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
@@ -55,6 +55,12 @@ def get_layout():
                 id=id_constants.COLLAPSE_ERROR_MODAL,
             ),
             get_signals(),
+            # place this store here for now -- if we need to add more stores we can refactor this
+            dcc.Store(
+                id=id_constants.VIEW_STORE,
+                data=[],
+                storage_type="local",
+            ),
         ],
     )
 
@@ -75,9 +81,6 @@ def get_signals():
         id_constants.SIGNAL_APPLIED_TAG_MODIFY,
         id_constants.SIGNAL_APPLIED_TAG_UPDATE,
         # ---
-        id_constants.SIGNAL_VIEW_CREATE,
-        id_constants.SIGNAL_VIEW_DELETE,
-        id_constants.SIGNAL_VIEW_MODIFY,
         id_constants.SIGNAL_VIEW_UPDATE,
         # ---
         id_constants.SIGNAL_STYLE_SAVE,
@@ -503,10 +506,9 @@ def get_create_tag_components():
     return [header] + tag_rows + [add_button_row, save_tag_toast]
 
 
-def get_view_components():
+def get_view_components(view_list: List[Tuple[str, str]]):
     tag_list = state.get_tag_list()
     style_map = state.get_style_map()
-    view_list = state.get_view_list()
 
     view_rows = []
     for idx, view_tuple in enumerate(view_list):

--- a/ujt/id_constants.py
+++ b/ujt/id_constants.py
@@ -34,9 +34,6 @@ SIGNAL_APPLIED_TAG_BATCH_ADD = "batch-add-applied-tag-signal"
 SIGNAL_APPLIED_TAG_BATCH_REMOVE = "batch-remove-applied-tag-signal"
 SIGNAL_APPLIED_TAG_UPDATE = "applied-tag-update-signal"
 
-SIGNAL_VIEW_CREATE = "create-view-signal"
-SIGNAL_VIEW_DELETE = "delete-view-signal"
-SIGNAL_VIEW_MODIFY = "modify-view-signal"
 SIGNAL_VIEW_UPDATE = "view-update-signal"
 
 SIGNAL_STYLE_SAVE = "save-style-signal"
@@ -119,6 +116,7 @@ VIEW_TAG_DROPDOWN = "view-tag-dropdown"
 VIEW_STYLE_DROPDOWN = "view-style-dropdown"
 DELETE_VIEW_BUTTON = "delete-view-button"
 CREATE_VIEW_BUTTON = "create-view-button"
+VIEW_STORE = "view-store"
 # endregion
 
 # region style

--- a/ujt/state.py
+++ b/ujt/state.py
@@ -518,54 +518,8 @@ def update_style(style_name: str, style_dict: Dict[str, str]):
 
 def delete_style(style_name: str):
     style_map = get_style_map()
-
-    view_list = get_view_list()
-    view_list = [
-        [view_tag, view_style_name]
-        for view_tag, view_style_name in view_list
-        if view_style_name != style_name
-    ]
-    set_view_list(view_list)
-
     del style_map[style_name]
     set_style_map(style_map)
-
-
-# endregion
-
-
-# region view list
-def get_view_list():
-    """Returns the list of created views, which associate a tag and a style.
-
-    This structure is a list since the ordering matters in the UI when displaying views.
-
-    Returns:
-        A list of all created views.
-    """
-    return cache.get(id_constants.VIEW_LIST)
-
-
-def set_view_list(view_list):
-    return cache.set(id_constants.VIEW_LIST, view_list)
-
-
-def create_view(tag, style):
-    view_list = get_view_list()
-    view_list.append([tag, style])
-    set_view_list(view_list)
-
-
-def update_view(view_idx, tag, style):
-    view_list = get_view_list()
-    view_list[view_idx] = [tag, style]
-    set_view_list(view_list)
-
-
-def delete_view(view_idx):
-    view_list = get_view_list()
-    del view_list[view_idx]
-    set_view_list(view_list)
 
 
 # endregion

--- a/ujt/transformers.py
+++ b/ujt/transformers.py
@@ -60,7 +60,7 @@ def apply_views(elements, tag_map, view_list):
             # Let's make that optimization later if this turns out to be excessively slow.
             for tag in tags:
                 for view_tag, view_style_name in view_list:
-                    if tag == view_tag and tag != "":
+                    if tag == view_tag and tag != "" and view_style_name != "":
                         class_list.append(view_style_name)
         element["classes"] += f" {' '.join(class_list)}"
 


### PR DESCRIPTION
I changed the views to be saved locally, so each user is isolated from each other's view settings. 

However, styles and tags are still stored on the server side, so changes to these structures affects all users.

This is how it was originally designed in the doc, but I implemented it incorrectly the first time.

closes #50