### PR TITLE
Fix dagre layout bug by introducing element reordering fix

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -311,3 +311,70 @@ def test_apply_uuid_to_elements(patch_path, assert_same_elements):
             node_elements + edge_elements
         )
         assert_same_elements(returned_elements, expected_elements)
+
+
+def test_sort_nodes_by_parent_relationship():
+    node_names = ["Node0", "Node1", "Node2", "Node3", "Node4"]
+    # Node0 contains Node1 and Node2
+    # Node1 contains Node3
+    # Node2 contains Node4
+    node_elements = [
+        {
+            "data": {
+                "id": node_names[0],
+            },
+        },
+        {
+            "data": {
+                "id": node_names[1],
+                "parent": node_names[0],
+            },
+        },
+        {
+            "data": {
+                "id": node_names[2],
+                "parent": node_names[0],
+            },
+        },
+        {
+            "data": {
+                "id": node_names[3],
+                "parent": node_names[1],
+            },
+        },
+        {
+            "data": {
+                "id": node_names[4],
+                "parent": node_names[2],
+            },
+        },
+    ]
+    # We declare the input in topological order so it's easier to understand
+    # Reverse so it's in reverse topological order
+    reversed_node_elements = node_elements[::-1]
+
+    edge_elements = [
+        {
+            "data": {
+                "source": node_names[0],
+                "target": node_names[1],
+            },
+        },
+    ]
+
+    returned_elements = ujt.transformers.sort_nodes_by_parent_relationship(
+        reversed_node_elements + edge_elements
+    )
+
+    assert returned_elements.index(node_elements[0]) < returned_elements.index(
+        node_elements[1]
+    )
+    assert returned_elements.index(node_elements[0]) < returned_elements.index(
+        node_elements[2]
+    )
+    assert returned_elements.index(node_elements[1]) < returned_elements.index(
+        node_elements[3]
+    )
+    assert returned_elements.index(node_elements[2]) < returned_elements.index(
+        node_elements[4]
+    )

--- a/ujt/callbacks/graph_callbacks.py
+++ b/ujt/callbacks/graph_callbacks.py
@@ -230,7 +230,7 @@ def update_graph_elements(
     # Workaround for https://github.com/plotly/dash-cytoscape/issues/106
     # Give new ids to Cytoscape to avoid immutability of edges and parent relationships.
     elements = transformers.apply_uuid_to_elements(elements, this_uuid=uuid)
-    elements = transformers.reorder_elements_by_type(elements)
+    elements = transformers.sort_nodes_by_parent_relationship(elements)
     return elements
 
 

--- a/ujt/callbacks/graph_callbacks.py
+++ b/ujt/callbacks/graph_callbacks.py
@@ -230,6 +230,7 @@ def update_graph_elements(
     # Workaround for https://github.com/plotly/dash-cytoscape/issues/106
     # Give new ids to Cytoscape to avoid immutability of edges and parent relationships.
     elements = transformers.apply_uuid_to_elements(elements, this_uuid=uuid)
+    elements = transformers.reorder_elements_by_type(elements)
     return elements
 
 

--- a/ujt/transformers.py
+++ b/ujt/transformers.py
@@ -378,6 +378,9 @@ def apply_slis_to_node_map(sli_list, node_map):
 def sort_nodes_by_parent_relationship(elements):
     """Returns a list of elements where node parents always appear before node children.
 
+    This method essentially performs a topological sort on the trees
+    formed from parent-child relationships between nodes.
+
     For context, see https://github.com/plotly/dash-cytoscape/issues/112
     and https://github.com/googleinterns/userjourneytool/issues/63
 
@@ -385,8 +388,9 @@ def sort_nodes_by_parent_relationship(elements):
         elements: a list of cytoscape elements.
 
     Returns:
-        a list of topologically sorted cytoscape elements.
+        a list of cytoscape where node parents always appear before node children.
     """
+
     edges = []
     node_id_element_map = {}
     for element in elements:
@@ -408,8 +412,13 @@ def sort_nodes_by_parent_relationship(elements):
             bfs_queue.append(node_id)
 
     topologically_sorted_nodes = []
+    visited_node_ids = set()
     while bfs_queue:
         node_id = bfs_queue.popleft()
+        if node_id in visited_node_ids:
+            raise ValueError("Circular parent/child relationship detected!")
+        else:
+            visited_node_ids.add(node_id)
         bfs_queue.extend(parent_child_map[node_id])
         topologically_sorted_nodes.append(node_id_element_map[node_id])
 

--- a/ujt/transformers.py
+++ b/ujt/transformers.py
@@ -373,3 +373,29 @@ def apply_slis_to_node_map(sli_list, node_map):
         node.slis.extend(new_node_slis)
 
     return node_map
+
+
+def reorder_elements_by_type(elements):
+    """Returns a list of elements organized by element type.
+
+    For context, see https://github.com/plotly/dash-cytoscape/issues/112
+    and https://github.com/googleinterns/userjourneytool/issues/63
+
+    Args:
+        elements: a list of cytoscape elements.
+
+    Retruns:
+        a list of cytoscape elements organized by element type.
+    """
+
+    # other_nodes holds elements representing parents, or nodes without children
+    edges, children, other_nodes = [], [], []
+    for element in elements:
+        if "source" in element["data"]:
+            edges.append(element)
+        elif "parent" in element["data"]:
+            children.append(element)
+        else:
+            other_nodes.append(element)
+
+    return edges + other_nodes + children


### PR DESCRIPTION
Without this fix, the layout renders as:
![image](https://user-images.githubusercontent.com/15064893/97233255-0d9f5f80-17b5-11eb-8942-c3accc554c1e.png)
or
![image](https://user-images.githubusercontent.com/15064893/97233265-12641380-17b5-11eb-9978-0b6ff0626f0f.png)

I'm not sure why this issue arose without any changes to the code or environment. Perhaps I was relying on some nondeterministic behavior when converting from an ordered type (dict or set) to a list.

For additional context, see https://github.com/plotly/dash-cytoscape/issues/112

closes #63 