### PR TITLE
Use Dash saved maps to persist override status and comments when refreshing topology

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -43,7 +43,11 @@ def test_get_message_maps_no_cache(patch_path):
     ) as mock_rpc_client_get_clients, patch(
         f"{patch_path}.utils.proto_list_to_name_map",
         Mock(side_effect=[sentinel.node_map, sentinel.client_map]),
-    ) as mock_proto_list_to_name_map:
+    ) as mock_proto_list_to_name_map, patch(
+        f"{patch_path}.get_override_status_map", Mock(return_value={})
+    ), patch(
+        f"{patch_path}.get_comment_map", Mock(return_value={})
+    ):
 
         assert (sentinel.node_map, sentinel.client_map) == ujt.state.get_message_maps()
 
@@ -216,7 +220,11 @@ def test_delete_virtual_node(patch_path):
         f"{patch_path}.set_virtual_node_map"
     ) as mock_set_virtual_node_map, patch(
         f"{patch_path}.set_parent_virtual_node_map"
-    ) as mock_set_parent_virtual_node_map:
+    ) as mock_set_parent_virtual_node_map, patch(
+        f"{patch_path}.get_override_status_map", Mock(return_value={})
+    ), patch(
+        f"{patch_path}.get_comment_map", Mock(return_value={})
+    ):
 
         ujt.state.delete_virtual_node(virtual_node_name)
 

--- a/ujt/callbacks/panel_callbacks.py
+++ b/ujt/callbacks/panel_callbacks.py
@@ -149,8 +149,10 @@ def generate_user_journey_info_panel(dropdown_value: str) -> List[Any]:
 
 @app.callback(
     Output(id_constants.CREATE_TAG_PANEL, "children"),
-    Input(id_constants.SIGNAL_TAG_CREATE, "children"),
-    Input(id_constants.SIGNAL_TAG_DELETE, "children"),
+    [
+        Input(id_constants.SIGNAL_TAG_CREATE, "children"),
+        Input(id_constants.SIGNAL_TAG_DELETE, "children"),
+    ],
 )
 def generate_create_tag_panel(create_tag_signal, delete_tag_signal):
     """Handles generating the tag creation and deletion panel.

--- a/ujt/id_constants.py
+++ b/ujt/id_constants.py
@@ -18,6 +18,20 @@ For now, signals use the component type first convention, and all other
 component ids place the component type at the end.
 """
 
+# region cache keys
+NODE_NAME_MESSAGE_MAP = "node_name_message_map"
+CLIENT_NAME_MESSAGE_MAP = "client_name_message_map"
+
+VIRTUAL_NODE_MAP = "virtual_node_map"
+PARENT_VIRTUAL_NODE_MAP = "parent_virtual_node_map"
+COMMENT_MAP = "comment_map"
+OVERRIDE_STATUS_MAP = "override_status_map"
+TAG_LIST = "tag_list"
+TAG_MAP = "tag_map"
+STYLE_MAP = "style_map"
+VIEW_LIST = "view_list"
+# endregion
+
 
 # region signals
 SIGNAL_VIRTUAL_NODE_ADD = "add-virtual-node-signal"
@@ -159,20 +173,6 @@ LOAD_STYLE_TEXTAREA_BUTTON = "load-style-textarea-button"
 SAVE_STYLE_TEXTAREA_BUTTON = "save-style-textarea-button"
 DELETE_STYLE_BUTTON = "delete-style-button"
 SAVE_STYLE_TOAST = "save-style-toast"
-# endregion
-
-# region cache keys
-NODE_NAME_MESSAGE_MAP = "node_name_message_map"
-CLIENT_NAME_MESSAGE_MAP = "client_name_message_map"
-
-VIRTUAL_NODE_MAP = "virtual_node_map"
-PARENT_VIRTUAL_NODE_MAP = "parent_virtual_node_map"
-COMMENT_MAP = "comment_map"
-OVERRIDE_STATUS_MAP = "override_status_map"
-TAG_LIST = "tag_list"
-TAG_MAP = "tag_map"
-STYLE_MAP = "style_map"
-VIEW_LIST = "view_list"
 # endregion
 
 # region change over time


### PR DESCRIPTION
I missed implementing this functionality when I changed the state saving convention of override status and comments.

Now, when the UJT requests the topology on startup, it remembers the previously set override and comment options.

closes #73