### PR TITLE
Fix integration test CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,5 +41,7 @@ jobs:
       run: |
         mypy ujt tests
     - name: Test
+      env:
+        PERCY_TOKEN: ${{ secrets.UJT_PERCY }}
       run: |
         ./test

--- a/config.ini
+++ b/config.ini
@@ -3,7 +3,7 @@
 # This should almost always be set to False.
 # Enabling this flag will remove all user defined tags, styles, views, 
 # override statuses, comments, and virtual nodes
-CLEAR_CACHE_ON_STARTUP=False
+CLEAR_CACHE_ON_STARTUP=True
 # Flag indicating whether the topology should be refreshed on startup.
 REFRESH_TOPOLOGY_ON_STARTUP=True
 

--- a/test
+++ b/test
@@ -1,2 +1,8 @@
 #!/bin/bash
-pytest --cov-report term-missing  --cov=ujt -vv
+if [ -z "$CI" ]
+then
+    pytest --cov-report term-missing --cov=ujt -vv -s --local
+else
+    pytest --cov-report term-missing --cov=ujt -vv
+fi
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,17 @@ import pytest
 from graph_structures_pb2 import SLI, Client, Dependency, Node, NodeType, UserJourney
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--local", action="store_true", default=False, help="run tests locally"
+    )
+
+
+@pytest.fixture
+def local(request):
+    return request.config.getoption("--local")
+
+
 @pytest.fixture
 def assert_same_elements():
     def inner_assert_same_elements(list1, list2):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,8 @@
+from selenium.webdriver.chrome.options import Options
+
+
+def pytest_setup_options():
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--disable-gpu")
+    return options

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,16 @@
+import os
+
 from selenium.webdriver.chrome.options import Options
 
 
 def pytest_setup_options():
     options = Options()
-    options.add_argument("--headless")
-    options.add_argument("--disable-gpu")
+    # This is a hack to determine if we're running in a CI environment
+    # (i.e. Github Actions).
+    # Since this is a pytest hook defined by Dash, we can't provide this
+    # function with additional arguments.
+    # Ideally, we would read from the "local" fixture defined in the toplevel conftest.
+    if "CI" in os.environ and os.environ["CI"] != "":
+        options.add_argument("--headless")
+        options.add_argument("--disable-gpu")
     return options

--- a/tests/integration/data/Client_MobileClient.ujtdata
+++ b/tests/integration/data/Client_MobileClient.ujtdata
@@ -1,0 +1,10 @@
+name: "MobileClient"
+user_journeys {
+  name: "MobileClient.PlayGame"
+  client_name: "MobileClient"
+  dependencies {
+    target_name: "APIServer.StartGame"
+    source_name: "MobileClient.PlayGame"
+    toplevel: true
+  }
+}

--- a/tests/integration/data/Client_WebBrowser.ujtdata
+++ b/tests/integration/data/Client_WebBrowser.ujtdata
@@ -1,0 +1,28 @@
+name: "WebBrowser"
+user_journeys {
+  name: "WebBrowser.ViewLeaderboard"
+  client_name: "WebBrowser"
+  dependencies {
+    target_name: "WebServer.GetLeaderboardPage"
+    source_name: "WebBrowser.ViewLeaderboard"
+    toplevel: true
+  }
+}
+user_journeys {
+  name: "WebBrowser.ViewProfile"
+  client_name: "WebBrowser"
+  dependencies {
+    target_name: "WebServer.GetProfilePage"
+    source_name: "WebBrowser.ViewProfile"
+    toplevel: true
+  }
+}
+user_journeys {
+  name: "WebBrowser.ConductMicrotransaction"
+  client_name: "WebBrowser"
+  dependencies {
+    target_name: "WebServer.BuyCurrency"
+    source_name: "WebBrowser.ConductMicrotransaction"
+    toplevel: true
+  }
+}

--- a/tests/integration/data/Node_APIServer.StartGame.ujtdata
+++ b/tests/integration/data/Node_APIServer.StartGame.ujtdata
@@ -1,0 +1,18 @@
+node_type: NODETYPE_ENDPOINT
+name: "APIServer.StartGame"
+parent_name: "APIServer"
+dependencies {
+  target_name: "APIServer.UpdateGameState"
+  source_name: "APIServer.StartGame"
+}
+slis {
+  node_name: "APIServer.StartGame"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.4122114975723222
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_APIServer.UpdateGameState.ujtdata
+++ b/tests/integration/data/Node_APIServer.UpdateGameState.ujtdata
@@ -1,0 +1,26 @@
+node_type: NODETYPE_ENDPOINT
+name: "APIServer.UpdateGameState"
+parent_name: "APIServer"
+dependencies {
+  target_name: "GameService.GetPlayerLocation"
+  source_name: "APIServer.UpdateGameState"
+}
+dependencies {
+  target_name: "GameService.GetScore"
+  source_name: "APIServer.UpdateGameState"
+}
+dependencies {
+  target_name: "LeaderboardService.SetUserHighScore"
+  source_name: "APIServer.UpdateGameState"
+}
+slis {
+  node_name: "APIServer.UpdateGameState"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.1306628193186249
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_APIServer.ujtdata
+++ b/tests/integration/data/Node_APIServer.ujtdata
@@ -1,0 +1,15 @@
+node_type: NODETYPE_SERVICE
+name: "APIServer"
+child_names: "APIServer.StartGame"
+child_names: "APIServer.UpdateGameState"
+slis {
+  node_name: "APIServer"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.9462078884941103
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_ExternalAuthProvider.ujtdata
+++ b/tests/integration/data/Node_ExternalAuthProvider.ujtdata
@@ -1,0 +1,13 @@
+node_type: NODETYPE_SERVICE
+name: "ExternalAuthProvider"
+slis {
+  node_name: "ExternalAuthProvider"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.8039378652539185
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_ExternalPaymentProvider.ujtdata
+++ b/tests/integration/data/Node_ExternalPaymentProvider.ujtdata
@@ -1,0 +1,13 @@
+node_type: NODETYPE_SERVICE
+name: "ExternalPaymentProvider"
+slis {
+  node_name: "ExternalPaymentProvider"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.715100696366318
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_GameDB.ReadHighScore.ujtdata
+++ b/tests/integration/data/Node_GameDB.ReadHighScore.ujtdata
@@ -1,0 +1,14 @@
+node_type: NODETYPE_ENDPOINT
+name: "GameDB.ReadHighScore"
+parent_name: "GameDB"
+slis {
+  node_name: "GameDB.ReadHighScore"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.012611395796766511
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_GameDB.WriteHighScore.ujtdata
+++ b/tests/integration/data/Node_GameDB.WriteHighScore.ujtdata
@@ -1,0 +1,14 @@
+node_type: NODETYPE_ENDPOINT
+name: "GameDB.WriteHighScore"
+parent_name: "GameDB"
+slis {
+  node_name: "GameDB.WriteHighScore"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.7867782079764702
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_GameDB.ujtdata
+++ b/tests/integration/data/Node_GameDB.ujtdata
@@ -1,0 +1,15 @@
+node_type: NODETYPE_SERVICE
+name: "GameDB"
+child_names: "GameDB.ReadHighScore"
+child_names: "GameDB.WriteHighScore"
+slis {
+  node_name: "GameDB"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.7566184295468327
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_GameService.GetPlayerLocation.ujtdata
+++ b/tests/integration/data/Node_GameService.GetPlayerLocation.ujtdata
@@ -1,0 +1,14 @@
+node_type: NODETYPE_ENDPOINT
+name: "GameService.GetPlayerLocation"
+parent_name: "GameService"
+slis {
+  node_name: "GameService.GetPlayerLocation"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.12695170629119124
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_GameService.GetScore.ujtdata
+++ b/tests/integration/data/Node_GameService.GetScore.ujtdata
@@ -1,0 +1,14 @@
+node_type: NODETYPE_ENDPOINT
+name: "GameService.GetScore"
+parent_name: "GameService"
+slis {
+  node_name: "GameService.GetScore"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.08478530943825524
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_GameService.ujtdata
+++ b/tests/integration/data/Node_GameService.ujtdata
@@ -1,0 +1,15 @@
+node_type: NODETYPE_SERVICE
+name: "GameService"
+child_names: "GameService.GetPlayerLocation"
+child_names: "GameService.GetScore"
+slis {
+  node_name: "GameService"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.6330819040658492
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_LeaderboardService.GetLeaderboard.ujtdata
+++ b/tests/integration/data/Node_LeaderboardService.GetLeaderboard.ujtdata
@@ -1,0 +1,18 @@
+node_type: NODETYPE_ENDPOINT
+name: "LeaderboardService.GetLeaderboard"
+parent_name: "LeaderboardService"
+dependencies {
+  target_name: "GameDB.ReadHighScore"
+  source_name: "LeaderboardService.GetLeaderboard"
+}
+slis {
+  node_name: "LeaderboardService.GetLeaderboard"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.07914790786579518
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_LeaderboardService.GetUserHighScore.ujtdata
+++ b/tests/integration/data/Node_LeaderboardService.GetUserHighScore.ujtdata
@@ -1,0 +1,18 @@
+node_type: NODETYPE_ENDPOINT
+name: "LeaderboardService.GetUserHighScore"
+parent_name: "LeaderboardService"
+dependencies {
+  target_name: "GameDB.ReadHighScore"
+  source_name: "LeaderboardService.GetUserHighScore"
+}
+slis {
+  node_name: "LeaderboardService.GetUserHighScore"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.002517266037311061
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_LeaderboardService.SetUserHighScore.ujtdata
+++ b/tests/integration/data/Node_LeaderboardService.SetUserHighScore.ujtdata
@@ -1,0 +1,18 @@
+node_type: NODETYPE_ENDPOINT
+name: "LeaderboardService.SetUserHighScore"
+parent_name: "LeaderboardService"
+dependencies {
+  target_name: "GameDB.WriteHighScore"
+  source_name: "LeaderboardService.SetUserHighScore"
+}
+slis {
+  node_name: "LeaderboardService.SetUserHighScore"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.24212482292448811
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_LeaderboardService.ujtdata
+++ b/tests/integration/data/Node_LeaderboardService.ujtdata
@@ -1,0 +1,16 @@
+node_type: NODETYPE_SERVICE
+name: "LeaderboardService"
+child_names: "LeaderboardService.GetLeaderboard"
+child_names: "LeaderboardService.SetUserHighScore"
+child_names: "LeaderboardService.GetUserHighScore"
+slis {
+  node_name: "LeaderboardService"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.9965599528727953
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_ProfileDB.ReadFriendsList.ujtdata
+++ b/tests/integration/data/Node_ProfileDB.ReadFriendsList.ujtdata
@@ -1,0 +1,14 @@
+node_type: NODETYPE_ENDPOINT
+name: "ProfileDB.ReadFriendsList"
+parent_name: "ProfileDB"
+slis {
+  node_name: "ProfileDB.ReadFriendsList"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.41022868789421285
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_ProfileDB.WriteFriendsList.ujtdata
+++ b/tests/integration/data/Node_ProfileDB.WriteFriendsList.ujtdata
@@ -1,0 +1,14 @@
+node_type: NODETYPE_ENDPOINT
+name: "ProfileDB.WriteFriendsList"
+parent_name: "ProfileDB"
+slis {
+  node_name: "ProfileDB.WriteFriendsList"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.4310742398857176
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_ProfileDB.ujtdata
+++ b/tests/integration/data/Node_ProfileDB.ujtdata
@@ -1,0 +1,15 @@
+node_type: NODETYPE_SERVICE
+name: "ProfileDB"
+child_names: "ProfileDB.ReadFriendsList"
+child_names: "ProfileDB.WriteFriendsList"
+slis {
+  node_name: "ProfileDB"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.13704146507217496
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_ProfileService.Authenticate.ujtdata
+++ b/tests/integration/data/Node_ProfileService.Authenticate.ujtdata
@@ -1,0 +1,18 @@
+node_type: NODETYPE_ENDPOINT
+name: "ProfileService.Authenticate"
+parent_name: "ProfileService"
+dependencies {
+  target_name: "ExternalAuthProvider"
+  source_name: "ProfileService.Authenticate"
+}
+slis {
+  node_name: "ProfileService.Authenticate"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.708870790925851
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_ProfileService.GetUserInfo.ujtdata
+++ b/tests/integration/data/Node_ProfileService.GetUserInfo.ujtdata
@@ -1,0 +1,22 @@
+node_type: NODETYPE_ENDPOINT
+name: "ProfileService.GetUserInfo"
+parent_name: "ProfileService"
+dependencies {
+  target_name: "LeaderboardService.GetUserHighScore"
+  source_name: "ProfileService.GetUserInfo"
+}
+dependencies {
+  target_name: "ProfileDB.ReadFriendsList"
+  source_name: "ProfileService.GetUserInfo"
+}
+slis {
+  node_name: "ProfileService.GetUserInfo"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.8959821760286485
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_ProfileService.ujtdata
+++ b/tests/integration/data/Node_ProfileService.ujtdata
@@ -1,0 +1,15 @@
+node_type: NODETYPE_SERVICE
+name: "ProfileService"
+child_names: "ProfileService.Authenticate"
+child_names: "ProfileService.GetUserInfo"
+slis {
+  node_name: "ProfileService"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.3684296770105876
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_StoreService.VerifyPayment.ujtdata
+++ b/tests/integration/data/Node_StoreService.VerifyPayment.ujtdata
@@ -1,0 +1,18 @@
+node_type: NODETYPE_ENDPOINT
+name: "StoreService.VerifyPayment"
+parent_name: "StoreService"
+dependencies {
+  target_name: "ExternalPaymentProvider"
+  source_name: "StoreService.VerifyPayment"
+}
+slis {
+  node_name: "StoreService.VerifyPayment"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.9099848351010008
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_StoreService.ujtdata
+++ b/tests/integration/data/Node_StoreService.ujtdata
@@ -1,0 +1,14 @@
+node_type: NODETYPE_SERVICE
+name: "StoreService"
+child_names: "StoreService.VerifyPayment"
+slis {
+  node_name: "StoreService"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.9355669382994208
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_WebServer.BuyCurrency.ujtdata
+++ b/tests/integration/data/Node_WebServer.BuyCurrency.ujtdata
@@ -1,0 +1,18 @@
+node_type: NODETYPE_ENDPOINT
+name: "WebServer.BuyCurrency"
+parent_name: "WebServer"
+dependencies {
+  target_name: "StoreService.VerifyPayment"
+  source_name: "WebServer.BuyCurrency"
+}
+slis {
+  node_name: "WebServer.BuyCurrency"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.30985937811496567
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_WebServer.GetLeaderboardPage.ujtdata
+++ b/tests/integration/data/Node_WebServer.GetLeaderboardPage.ujtdata
@@ -1,0 +1,18 @@
+node_type: NODETYPE_ENDPOINT
+name: "WebServer.GetLeaderboardPage"
+parent_name: "WebServer"
+dependencies {
+  target_name: "LeaderboardService.GetLeaderboard"
+  source_name: "WebServer.GetLeaderboardPage"
+}
+slis {
+  node_name: "WebServer.GetLeaderboardPage"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.702985403198639
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_WebServer.GetProfilePage.ujtdata
+++ b/tests/integration/data/Node_WebServer.GetProfilePage.ujtdata
@@ -1,0 +1,22 @@
+node_type: NODETYPE_ENDPOINT
+name: "WebServer.GetProfilePage"
+parent_name: "WebServer"
+dependencies {
+  target_name: "ProfileService.Authenticate"
+  source_name: "WebServer.GetProfilePage"
+}
+dependencies {
+  target_name: "ProfileService.GetUserInfo"
+  source_name: "WebServer.GetProfilePage"
+}
+slis {
+  node_name: "WebServer.GetProfilePage"
+  sli_type: SLITYPE_LATENCY
+  sli_value: 0.8752218295796563
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/data/Node_WebServer.ujtdata
+++ b/tests/integration/data/Node_WebServer.ujtdata
@@ -1,0 +1,16 @@
+node_type: NODETYPE_SERVICE
+name: "WebServer"
+child_names: "WebServer.GetProfilePage"
+child_names: "WebServer.GetLeaderboardPage"
+child_names: "WebServer.BuyCurrency"
+slis {
+  node_name: "WebServer"
+  sli_type: SLITYPE_AVAILABILITY
+  sli_value: 0.6916156874174165
+  slo_error_upper_bound: 0.9
+  slo_error_lower_bound: 0.1
+  slo_warn_upper_bound: 0.8
+  slo_warn_lower_bound: 0.2
+  slo_target: 0.5
+  intra_status_change_threshold: 0.03
+}

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -10,7 +10,7 @@ import ujt.main
 import ujt.server.server
 
 
-def test_main_ui(dash_duo):
+def test_main_ui(dash_duo, local):
     # Start the reporting server
     ready_event = threading.Event()
     server_thread = threading.Thread(
@@ -58,4 +58,5 @@ def test_main_ui(dash_duo):
     )
     dash_duo.driver.execute_script(replace_canvas_with_image_script, node_canvas)
 
-    dash_duo.percy_snapshot("main_ui", wait_for_callbacks=True)
+    if not local:
+        dash_duo.percy_snapshot("main_ui", wait_for_callbacks=True)

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -12,15 +12,19 @@ import ujt.server.server
 
 def test_main_ui(dash_duo):
     # Start the reporting server
+    ready_event = threading.Event()
     server_thread = threading.Thread(
         target=ujt.server.server.serve,
         args=(
             "50052",
             pathlib.Path(__file__).parent.absolute() / "data",
+            ready_event,
         ),
-        daemon=True,  # kill the thread when the test stops
+        # stop process when only server thread exists (after test completed)
+        daemon=True,
     )
     server_thread.start()
+    ready_event.wait()
 
     # initialize the ujt
     ujt.config.REPORTING_SERVER_ADDRESS = "localhost:50052"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -20,6 +20,7 @@ def test_clear_sli_cache(patch_path):
 
 
 def test_get_slis(patch_path):
+    ujt.state.clear_sli_cache()
     with patch(f"{patch_path}.rpc_client.get_slis") as mock_rpc_client_get_slis, patch(
         f"{patch_path}.list"
     ) as mock_list:

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -331,6 +331,7 @@ def test_sort_nodes_by_parent_relationship():
             "data": {
                 "source": node_names[0],
                 "target": node_names[1],
+                "id": f"{node_names[0]}/{node_names[1]}",
             },
         },
     ]
@@ -339,15 +340,19 @@ def test_sort_nodes_by_parent_relationship():
         reversed_node_elements + edge_elements
     )
 
-    assert returned_elements.index(node_elements[0]) < returned_elements.index(
-        node_elements[1]
-    )
-    assert returned_elements.index(node_elements[0]) < returned_elements.index(
-        node_elements[2]
-    )
-    assert returned_elements.index(node_elements[1]) < returned_elements.index(
-        node_elements[3]
-    )
-    assert returned_elements.index(node_elements[2]) < returned_elements.index(
-        node_elements[4]
-    )
+    expected_elements = [
+        {
+            "data": {
+                "source": f"{node_names[0]}",
+                "target": f"{node_names[1]}",
+                "id": f"{node_names[0]}/{node_names[1]}",
+            }
+        },
+        {"data": {"id": f"{node_names[0]}"}},
+        {"data": {"id": f"{node_names[1]}", "parent": f"{node_names[0]}"}},
+        {"data": {"id": f"{node_names[2]}", "parent": f"{node_names[0]}"}},
+        {"data": {"id": f"{node_names[3]}", "parent": f"{node_names[1]}"}},
+        {"data": {"id": f"{node_names[4]}", "parent": f"{node_names[2]}"}},
+    ]
+
+    assert returned_elements == expected_elements

--- a/ujt/server/server.py
+++ b/ujt/server/server.py
@@ -4,6 +4,7 @@ import argparse
 import datetime as dt
 import pathlib
 import random
+import threading
 from concurrent import futures
 from typing import TYPE_CHECKING, Dict, List
 
@@ -220,7 +221,11 @@ class ReportingServiceServicer(server_pb2_grpc.ReportingServiceServicer):
         return server_pb2.GetSLIsResponse(slis=output_slis)
 
 
-def serve(port: str = None, data_path_str: str = None):
+def serve(
+    port: str = None,
+    data_path_str: str = None,
+    ready_event: threading.Event = None,
+):
     if port is None:
         port = "50052"
 
@@ -236,6 +241,8 @@ def serve(port: str = None, data_path_str: str = None):
 
     server.start()
     print(f"starting server on port {port}!")
+    if ready_event is not None:
+        ready_event.set()
     server.wait_for_termination()
 
 

--- a/ujt/transformers.py
+++ b/ujt/transformers.py
@@ -440,9 +440,16 @@ def sort_nodes_by_parent_relationship(elements):
 
     parent_child_map = defaultdict(list)
     bfs_queue = deque()
-    # build a tree from parents to children
+
+    lexicographically_sorted_edges = sorted(edges, key=lambda edge: edge["data"]["id"])
+    # initially sort the nodes to ensure a consistent traversal order, for a consistent layout
+    lexicographically_sorted_nodes = sorted(
+        node_id_element_map.values(), key=lambda node: node["data"]["id"]
+    )
+
+    # build a tree from parents to children (parent_child_map)
     # (reversing the edge direction of cytoscape format)
-    for node in node_id_element_map.values():
+    for node in lexicographically_sorted_nodes:
         node_id = node["data"]["id"]
         if "parent" in node["data"]:
             parent_id = node["data"]["parent"]
@@ -461,4 +468,4 @@ def sort_nodes_by_parent_relationship(elements):
         bfs_queue.extend(parent_child_map[node_id])
         topologically_sorted_nodes.append(node_id_element_map[node_id])
 
-    return edges + topologically_sorted_nodes
+    return lexicographically_sorted_edges + topologically_sorted_nodes


### PR DESCRIPTION
Make CI run integration tests properly!

Please use the file filter in the change list to filter out .ujtdata files -- these are used so the reporting server can run on Github Actions and has a consistent dataset to use.